### PR TITLE
Make sort order of property keys case-insensitive

### DIFF
--- a/ConfigReport.py
+++ b/ConfigReport.py
@@ -285,7 +285,7 @@ def reportProperties(rptParms):
 				cu.printException('Excpetion in reportProperties',sys.exc_info())
 				continue
 		if len(names) > 0:
-			names.sort()
+			names = sorted(names, key=str.lower)
 			tableData=[]
 			match=[]
 			for name in names:


### PR DESCRIPTION
Changes the display sort order of property sub-tables in html reports.  
Sorting is now performed ignoring case: instead of "A,B,a,b" , sort order is now "A,a,B,b".

see issue #12

Signed-off-by: thikade <thomas.hikade@gmail.com>